### PR TITLE
Fix: Depend on svelte as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "sinon-chai": "^2.8.0",
     "svelte": "^1.0.7"
   },
+  "peerDependencies": {
+    "svelte": "^1.0.7"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:svelte/svelte-loader.git"


### PR DESCRIPTION
This allows developers to install svelte-loader from npm
while having full control over the actual version being used.