### PR TITLE
Added svelte as a dependency to the example

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -15,5 +15,8 @@
     "babel-preset-es2015": "^6.18.0",
     "svelte-loader": "1.0.0",
     "webpack": "^2.1.0-beta.27"
+  },
+  "dependencies": {
+    "svelte": "^1.1.3"
   }
 }


### PR DESCRIPTION
1.0.1 made svelte a peerDependency to svelte-loader. This pull request just adds svelte as a dependency to the example.