### PR TITLE
fix renamed method parseQuery => getOptions from loader-utils

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 const { compile } = require('svelte');
-const { parseQuery } = require('loader-utils');
+const { getOptions } = require('loader-utils');
 
 module.exports = function(source, map) {
   this.cacheable();
 
   const filename = this.resourcePath;
-  const query = parseQuery(this.query);
+  const query = getOptions(this.query);
 
   try {
     let { code, map } = compile(source, {


### PR DESCRIPTION
See https://github.com/webpack/loader-utils/commit/dfe2608c0f0b3b816df816da63bb532b5609515a#diff-6d186b954a58d5bb740f73d84fe39073L3