### PR TITLE
Add optional support for code-coverage of generated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Configure inside your `webpack.config.js`:
 Checkout [example setup](./example).
 
 
+## Loader Options
+
+- `mapGeneratedSource`: use the generated-code as the "source" for code coverage tools (like Istanbul). Defaults to *false*.
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -23,11 +23,18 @@ module.exports = function(source, map) {
   options.filename = this.resourcePath;
   options.format = this.version === 1 ? options.format || 'cjs' : 'es';
   options.shared = options.format === 'es' && require.resolve( 'svelte/shared.js' );
+  options.mapGeneratedSource = !!options.mapGeneratedSource;
 
   if (!options.name) options.name = capitalize(sanitize(options.filename));
 
   try {
     let { code, map } = compile(source, options);
+
+    map = Object.assign({}, map);
+
+    if (options.mapGeneratedSource) {
+      map.sourcesContent = [code];
+    }
 
     this.callback(null, code, map);
   } catch (err) {

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "mocha": "^3.2.0",
     "sinon": "^1.17.6",
     "sinon-chai": "^2.8.0",
-    "svelte": "^1.6.0"
+    "svelte": "^1.16.0"
   },
   "peerDependencies": {
-    "svelte": "^1.0.7"
+    "svelte": "^1.16.0"
   },
   "repository": {
     "type": "git",

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -49,6 +49,33 @@ describe('loader', function() {
   );
 
 
+  describe('sourcemap', function() {
+    it('should produce a sourcemap that is a "plain" object',
+      testLoader('test/fixtures/css.html', function(err, code, map) {
+        // expect(typeof map.toString).not.to.equal('function');
+        let proto = Object.getPrototypeOf(map);
+        let ctor = hasOwnProperty.call(proto, 'constructor') && proto.constructor;
+        let isPlainObject = typeof ctor == 'function' && ctor instanceof ctor &&  Function.prototype.toString.call(ctor) == Function.prototype.toString.call(Object);
+
+        expect(isPlainObject).to.equal(true);
+        expect(map).not.to.have.property('toUrl');
+      })
+    );
+
+    it('should set sourcesContent to the generated code when mapGeneratedSource is true',
+      testLoader('test/fixtures/css.html', function(err, code, map) {
+        expect(code).to.deep.equal(map.sourcesContent[0]);
+      }, { mapGeneratedSource: true })
+    );
+
+    it('should not set sourcesContent to the generated code by default',
+      testLoader('test/fixtures/css.html', function(err, code, map) {
+        expect(code).to.not.deep.equal(map.sourcesContent[0]);
+      })
+    );
+  });
+
+
   describe('error handling', function() {
 
     it('should handle parse error',

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -151,7 +151,7 @@ describe('loader', function() {
       it('should configure css (default)',
         testLoader('test/fixtures/css.html', function(err, code, map) {
           expect(err).not.to.exist;
-          expect(code).to.contain('if ( !addedCss ) addCss();');
+          expect(code).to.contain('if ( !added_css ) add_css();');
         })
       );
 
@@ -159,7 +159,7 @@ describe('loader', function() {
       it('should configure no css',
         testLoader('test/fixtures/css.html', function(err, code, map) {
           expect(err).not.to.exist;
-          expect(code).not.to.contain('if ( !addedCss ) addCss();');
+          expect(code).not.to.contain('if ( !added_css ) add_css();');
         }, { css: false })
       );
 


### PR DESCRIPTION
Fixes #22 

Example output from Webpack + Karma + karma-coverage:
```bash
--------------------------|----------|----------|----------|----------|----------------|
File                      |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
--------------------------|----------|----------|----------|----------|----------------|
 notifications/           |    70.76 |     28.4 |    77.78 |    72.61 |                |
  notification.html       |    73.12 |       30 |    76.92 |    74.16 |... 155,156,157 |
  notificationsPanel.html |    67.95 |    27.45 |    78.57 |    70.59 |... 159,161,162 |
  statuses.js             |      100 |      100 |      100 |      100 |                |
  types.js                |      100 |      100 |      100 |      100 |                |
--------------------------|----------|----------|----------|----------|----------------|
All files                 |    70.76 |     28.4 |    77.78 |    72.61 |                |
--------------------------|----------|----------|----------|----------|----------------|
```

karma.config.js:
```js
// Global karma config
'use strict';

const DefinePlugin = require('webpack').DefinePlugin;   // Needed to pass the testFilesRegEx to test.files.js
let testFilesRegEx = /unitTest\/.*spec\.(js|jsx)$/;

// Customise the testFilesRegEx to filter which files to test, if desired.
// Remember to also update .babelrc

// We want to re-use the loaders from the dev.webpack.config
let webpackConfig = require('./../webpack/dev.webpack.config.js');
let preprocessorList = ['webpack', 'sourcemap'];

let karmaConfig = {
  autoWatch: true,

  // base path, that will be used to resolve files and exclude
  basePath: '../../',

  // testing framework to use (jasmine/mocha/qunit/...)
  frameworks: ['jasmine'],

  // list of files / patterns to exclude
  exclude: [],

  // web server default port
  port: 8081,

  // Start these browsers, currently available:
  // - Chrome, ChromeCanary, Firefox, Opera, Safari (only Mac), PhantomJS, IE (only Windows)
  browsers: [
    'PhantomJS'
  ],

  plugins: [
    'karma-phantomjs-launcher',
    'karma-jasmine',
    'karma-junit-reporter',
    'karma-coverage',
    'karma-chrome-launcher',
    require('karma-webpack'),
    'karma-sourcemap-loader',
    'karma-threshold-reporter'
  ],

  files: [
    'node_modules/phantomjs-polyfill/bind-polyfill.js',
    'node_modules/phantomjs-polyfill-object-assign/object-assign-polyfill.js',
    'config/testUnit/test.files.js'
  ],

  preprocessors: {
    'config/testUnit/test.files.js': preprocessorList
  },

  reporters: ['progress', 'junit', 'coverage', 'threshold'],

  coverageReporter: {
    dir: 'reports/coverage/',
    reporters: [
      { type: 'cobertura', subdir: 'cobertura' },
      { type: 'lcovonly', subdir: 'lcov' },
      { type: 'html', subdir: 'html' },
      { type: 'json', subdir: 'json' },
      { type: 'text' }
    ],
    // --------------------- Extra config required (start) -------------------------
    // A custom report collector for Svelte HTML components, so that source maps display for generated code
    _onWriteReport: function(collector) {
      // Iterate over the keys of the collector.
      // If the collector key is a HTML file, do this: coverage.code = coverage.inputSourceMap.code
      var store = collector.store;
      var keys = store.keys().filter(function(key) {
        return /\.html$/.test(key);
      });

      keys.forEach(function(key) {
        let coverage = store.getObject(key);

        if (coverage.inputSourceMap) {
          // Replace the existing key with one that has the code property
          coverage.code = coverage.inputSourceMap.sourcesContent[0].split(/(?:\r?\n)|\r/);
          store.set(key, JSON.stringify(coverage))
        }
      });

      return collector;
    }
    // --------------------- Extra config required (end) -------------------------
  },

  junitReporter: {
    outputDir: 'reports/unit/'
  },

  thresholdReporter: require('./thresholds.json'),

  // Webpack please don't spam the console when running in karma!
  webpackMiddleware: { stats: 'errors-only'},

  singleRun: false,
  colors: true
};

webpackConfig.plugins.push(new DefinePlugin({
  __karmaTestSpec: testFilesRegEx
}));

// Change devtool to allow the sourcemap loader to work: https://github.com/webpack/karma-webpack
webpackConfig.devtool = 'inline-source-map';

// Turn off performance hints
webpackConfig.performance.hints = false;

karmaConfig.webpack = webpackConfig;

module.exports = karmaConfig;
```