### PR TITLE
Don't resolve the shared.js to the full local path

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = function(source, map) {
 	options.filename = this.resourcePath;
 	options.format = this.version === 1 ? options.format || 'cjs' : 'es';
 	options.shared =
-			options.format === 'es' && require.resolve('svelte/shared.js');
+			options.format === 'es' && 'svelte/shared.js';
 
 	if (options.emitCss) options.css = false;
 


### PR DESCRIPTION
Using the full local path exposes security/privacy issues when svelte components are provided as NPM modules. The compiled code includes the path information in the variable names. This also bloats the code, which isn't as much an issue since it eventually gets compressed with libraries such as uglify. The bigger issue is the local path information being publicized this way.

Are there any issues with removing `require.resolve`? Svelte should be available without it, but perhaps there are edge cases I cannot think of.

See https://github.com/sveltejs/svelte-loader/issues/29