### PR TITLE
make the path returned by tmpdir() posix style slashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,10 @@ const { getOptions } = require('loader-utils');
 const { statSync, utimesSync, writeFileSync } = require('fs');
 const { tmpdir } = require('os');
 
+function posixify(file) {
+	return file.replace(/[/\\]/g, '/');
+}
+
 function sanitize(input) {
 	return basename(input).
 			replace(extname(input), '').
@@ -36,7 +40,8 @@ module.exports = function(source, map) {
 		let { code, map, css, cssMap, ast } = compile(processed.toString(), options);
 
 		if (options.emitCss && css) {
-			const tmpFile = posix.join(tmpdir(), 'svelte-' + ast.hash + '.css');
+			const posixTmpdir = posixify(tmpdir());
+			const tmpFile = posix.join(posixTmpdir, 'svelte-' + ast.hash + '.css');
 
 			css += '\n/*# sourceMappingURL=' + cssMap.toUrl() + '*/';
 			code = code + `\nrequire('${tmpFile}');\n`;


### PR DESCRIPTION
The Pull Request https://github.com/sveltejs/svelte-loader/pull/34 introduced `posix.join` to fix Windows paths but this doesn't convert the path separators returned from `tmpdir` to be `/` slashes. I think this results in webpack having paths with escaped characters. 

This path is the result of `posix.join(tmpdir(), 'svelte-12415.css')`
`C:\Users\Bryan\AppData\Local\Temp/svelte-12415.css` 

webpack reports an error finding a module with this path
`C:UsersBryanAppDataLocalTemp/svelte-12415.css`. 

This PR replaces the `\` with `/` to make it posix style.

Node Version: v8.9.2
Windows 10 Version: 1709, Build: 116299.125
svelte-loader Version: 2.3.2

Thank you :)