### PR TITLE
Allow for `shared` and `format` options to be overridden

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,9 +24,12 @@ module.exports = function(source, map) {
 	const callback = this.async();
 
 	options.filename = this.resourcePath;
-	options.format = this.version === 1 ? options.format || 'cjs' : 'es';
-	options.shared =
-			options.format === 'es' && 'svelte/shared.js';
+	if (!options.format) {
+		options.format = this.version === 1 ? options.format || 'cjs' : 'es';
+	}
+	if (!options.shared) {
+		options.shared = options.format === 'es' && 'svelte/shared.js';
+	}
 
 	if (options.emitCss) options.css = false;
 


### PR DESCRIPTION
Maybe I am missing something, but I think we should allow for these options to be overridden.