### PR TITLE
Hot loading support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,84 @@ module.exports = {
 
 This should create an additional `styles.css.map` file.
 
+### Hot Reload
+
+Hot reloading is turned off by default, you can turn it on using the `hotReload` option as shown below:
+
+```javascript
+  ...
+  module: {
+    rules: [
+      ...
+      {
+        test: /\.(html|svelte)$/,
+        exclude: /node_modules/,
+        use: 'svelte-loader',
+        options: {
+          hotReload: true
+        }
+      }
+      ...
+    ]
+  }
+  ...
+```
+
+#### Hot reload rules and caveats:
+
+ - `_rerender` and `_register` are reserved method names, please don't use them in `methods:{...}`
+ - Turning `dev` mode on (`dev:true`) is **not** necessary.
+ - Modifying the HTML (template) part of your component will replace and re-render the changes in place. Current local state of the component will also be preserved (this can be turned off per component see [Stop preserving state](#stop-preserving-state)).
+ - When modifying the `<script>` part of your component, instances will be replaced and re-rendered in place too.
+  However if your component has lifecycle methods that produce global side-effects, you might need to reload the whole page.
+ - If you are using `svelte/store`, a full reload is required if you modify `store` properties
+
+
+Components will **not** be hot reloaded in the following situations:
+ 1. `process.env.NODE_ENV === 'production'`
+ 2. Webpack is minifying code
+ 3. Webpack's `target` is `node` (i.e SSR components)
+ 4. `generate` option has a value of `ssr`
+
+#### Stop preserving state
+
+Sometimes it might be necessary for some components to avoid state preservation on hot reload.
+
+This can be configured on a per-component basis by adding a property `noPreserveState = true` to the component's constructor using the `setup()` method. For example:
+```js
+export default {
+  setup(comp){
+    comp.noPreserveState = true;
+  },
+  data(){return {...}},
+  oncreate(){...}
+}
+```
+
+Or, on a global basis by adding `{noPreserveState: true}` to `hotOptions`. For example:
+```js
+{
+    test: /\.(html|svelte)$/,
+    exclude: /node_modules/,
+    use: [
+      {
+        loader: 'svelte-loader',
+        options: {
+          hotReload: true,
+          hotOptions: {
+            noPreserveState: true
+          }
+        }
+      }
+    ]
+  }
+```
+
+**Please Note:** If you are using `svelte/store`, `noPreserveState` has no effect on `store` properties. Neither locally, nor globally.
+
+
+
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -52,11 +52,11 @@ function capitalize(str) {
 module.exports = function(source, map) {
 	this.cacheable();
 
-	const isServer = this.target === 'node';
-	const isProduction = this.minimize || process.env.NODE_ENV === 'production';
-
 	const options = Object.assign({}, this.options, getOptions(this));
 	const callback = this.async();
+
+	const isServer = this.target === 'node' || (options.generate && options.generate == 'ssr');
+	const isProduction = this.minimize || process.env.NODE_ENV === 'production';
 
 	options.filename = this.resourcePath;
 	options.format = this.version === 1 ? options.format || 'cjs' : 'es';

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-const { basename, extname, posix } = require('path');
+const { basename, extname, posix, relative } = require('path');
 const { compile, preprocess } = require('svelte');
-const { getOptions, stringifyRequest } = require('loader-utils');
+const { getOptions } = require('loader-utils');
 const { statSync, utimesSync, writeFileSync } = require('fs');
 const { tmpdir } = require('os');
 
@@ -79,7 +79,7 @@ module.exports = function(source, map) {
 		}
 
 		if (options.hotReload && !isProduction && !isServer) {
-			const id = stringifyRequest(this, `!!${this.request}`);
+			const id = JSON.stringify(relative(process.cwd(), options.filename));
 			code = makeHot(id, code);
 		}
 

--- a/index.js
+++ b/index.js
@@ -48,6 +48,9 @@ function capitalize(str) {
 module.exports = function(source, map) {
 	this.cacheable();
 
+	const isServer = this.target === 'node';
+	const isProduction = this.minimize || process.env.NODE_ENV === 'production';
+
 	const options = Object.assign({}, this.options, getOptions(this));
 	const callback = this.async();
 
@@ -75,7 +78,7 @@ module.exports = function(source, map) {
 			utimesSync(tmpFile, new Date(atime.getTime() - 99999), new Date(mtime.getTime() - 99999));
 		}
 
-		if (options.hotReload) {
+		if (options.hotReload && !isProduction && !isServer) {
 			const id = stringifyRequest(this, `!!${this.request}`);
 			code = makeHot(id, code);
 		}

--- a/index.js
+++ b/index.js
@@ -15,9 +15,9 @@ if (module.hot) {
 
 	module.hot.accept();
 
-	if(!module.hot.data){
+	if (!module.hot.data) {
 		proxyComponent = register(${id}, $2);
-	}else{
+	} else {
 		reload(${id}, proxyComponent);
 	}
 }

--- a/lib/hot-api.js
+++ b/lib/hot-api.js
@@ -1,40 +1,40 @@
 import { Registry, configure as configureProxy, createProxy } from 'svelte-dev-helper';
 
 let hotOptions = {
-  noPreserveState: false
+	noPreserveState: false
 };
 
 export function configure(options) {
-  hotOptions = Object.assign(hotOptions, options);
-  configureProxy(hotOptions);
+	hotOptions = Object.assign(hotOptions, options);
+	configureProxy(hotOptions);
 }
 
 export function register(id, component) {
 
-  //store original component in registry
-  Registry.set(id, {
-    rollback: null,
-    component,
-    instances: []
-  });
+	//store original component in registry
+	Registry.set(id, {
+		rollback: null,
+		component,
+		instances: []
+	});
 
-  return createProxy(id);
+	return createProxy(id);
 }
 
 export function reload(id, component) {
 
-  const record = Registry.get(id);
+	const record = Registry.get(id);
 
-  //keep reference to previous version to enable rollback
-  record.rollback = record.component;
+	//keep reference to previous version to enable rollback
+	record.rollback = record.component;
 
-  //replace component in registry with newly loaded component
-  record.component = component;
+	//replace component in registry with newly loaded component
+	record.component = component;
 
-  Registry.set(id, record);
+	Registry.set(id, record);
 
-  //re-render the proxies
-  record.instances.slice().forEach(function (instance) {
-    instance && instance._rerender();
-  });
+	//re-render the proxies
+	record.instances.slice().forEach(function(instance) {
+		instance && instance._rerender();
+	});
 }

--- a/lib/hot-api.js
+++ b/lib/hot-api.js
@@ -1,0 +1,40 @@
+import { Registry, configure as configureProxy, createProxy } from 'svelte-dev-helper';
+
+let hotOptions = {
+  noPreserveState: false
+};
+
+export function configure(options) {
+  hotOptions = Object.assign(hotOptions, options);
+  configureProxy(hotOptions);
+}
+
+export function register(id, component) {
+
+  //store original component in registry
+  Registry.set(id, {
+    rollback: null,
+    component,
+    instances: []
+  });
+
+  return createProxy(id);
+}
+
+export function reload(id, component) {
+
+  const record = Registry.get(id);
+
+  //keep reference to previous version to enable rollback
+  record.rollback = record.component;
+
+  //replace component in registry with newly loaded component
+  record.component = component;
+
+  Registry.set(id, record);
+
+  //re-render the proxies
+  record.instances.slice().forEach(function (instance) {
+    instance && instance._rerender();
+  });
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "all": "npm run lint && npm run test",
     "test": "mocha --harmony --full-trace --check-leaks",
-    "lint": "eslint index.js test/**/*.js"
+    "lint": "eslint index.js lib/*.js test/**/*.js"
   },
   "keywords": [
     "svelte",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   ],
   "dependencies": {
     "loader-utils": "^1.1.0",
-    "tmp": "0.0.31"
+    "tmp": "0.0.31",
+    "svelte-dev-helper": "1.1.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "loader-utils": "^1.1.0",
     "tmp": "0.0.31",
-    "svelte-dev-helper": "1.1.0"
+    "svelte-dev-helper": "^1.1.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "loader-utils": "^1.1.0",
     "tmp": "0.0.31",
-    "svelte-dev-helper": "^1.1.1"
+    "svelte-dev-helper": "^1.1.2"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -341,6 +341,70 @@ describe('loader', () => {
 
 			});
 		});
+
+		describe('hotReload', () => {
+			it(
+				'should configure hotReload=false (default)',
+				testLoader(
+					'test/fixtures/good.html',
+					function(err, code, map) {
+						expect(err).not.to.exist;
+
+						expect(code).not.to.contain('module.hot.accept();');
+					},
+					{}
+				)
+			);
+
+			it(
+				'should configure hotReload=true',
+				testLoader(
+					'test/fixtures/good.html',
+					function(err, code, map) {
+						expect(err).not.to.exist;
+
+						expect(code).to.contain('module.hot.accept();');
+						expect(code).not.to.contain('configure({"noPreserveState":true});');
+					},
+					{ hotReload: true }
+				)
+			);
+
+			it(
+				'should configure hotReload=true & hotOptions',
+				testLoader(
+					'test/fixtures/good.html',
+					function(err, code, map) {
+						expect(err).not.to.exist;
+
+						expect(code).to.contain('module.hot.accept();');
+						expect(code).to.contain('configure({"noPreserveState":true});');
+					},
+					{
+						hotReload: true,
+						hotOptions: {
+							noPreserveState: true
+						}
+					}
+				)
+			);
+
+			it(
+				'should ignore hotReload when generate=ssr',
+				testLoader(
+					'test/fixtures/good.html',
+					function(err, code, map) {
+						expect(err).not.to.exist;
+
+						expect(code).not.to.contain('module.hot.accept();');
+					},
+					{
+						hotReload: true,
+						generate:'ssr'
+					}
+				)
+			);
+		});
 	});
 });
 


### PR DESCRIPTION
IMHO Hot loading should be baked in here rather than relying on a separate plugin as per [svelte-hot-loader](https://github.com/ekhaled/svelte-hot-loader)

This PR is feature complete, including tests and doc updates, and is ready for review.

Below is a brief overview of how it all works.

### Proxy
It works by using a proxy class to wrap the actual component. Once wrapped, for all intents and purposes, the proxy masquerades as the component.
It forwards all method calls (including custom methods) to the wrapped component and references all relevant component properties.

For some methods, such as `constructor`, `_mount`, `_unmount` and `destroy`, the proxy does some additional book-keeping before forwarding the method calls.

The proxy then adds a couple of extra methods, `_register` and `_rerender` (which I'll explain later).

### Registry
There is a global Registry that holds references to un-proxied original components (before they get proxied). It also holds references to all rendered instances of a particular component.
There is also a `rollback` key that helps in rolling back in case there is an error with a component after hot reload.

The signature of a registry item looks like this:
```js
{
  rollback: <Component>,
  component: <Component>,
  instances: [<Array>]
}
```

### Combination of Proxy and Registry
When a component (_remember the component is actually the proxy now_) is instantiated. It uses the `_register` method to resolve the actual component from the **Registry**, instantiates it, and then starts proxying its methods and properties.
It also registers it's current instance in the **Registry**;

When the same component gets hot reloaded... First the `rollback` property in the **Registry** is updated with the last version of the component.
Then the **Registry** is updated with the new version of the component.
Then we go through all the instances in the **Registry** and call the `_rerender` method on them.

On `_rerender` the proxy stores all props that need to carry over, such as `state`, `options`, `target` etc.
Destroys the proxied component.
Calls the `_register` method to resolve newest version of component.
`_mount`s the component in the same place if it was already mounted.
Finally, it restores the `state` from the old version of the component.

If there is an error during `_register` (e.g: a missing `import`), it's caught, logged in the console, and then an attempt is made to instantiate the component stored in `rollback`.
