### PR TITLE
fix for ekhaled/svelte-hot-loader#10

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,6 @@ function makeHot(id, code, hotOptions) {
 	const options = JSON.stringify(hotOptions);
 	const replacement = `
 
-let proxyComponent = $2;
-
 if (module.hot) {
 
 	const { configure, register, reload } = require('svelte-loader/lib/hot-api');
@@ -19,14 +17,15 @@ if (module.hot) {
 	if (!module.hot.data) {
 		// initial load
 		configure(${options});
-		proxyComponent = register(${id}, $2);
+		$2 = register(${id}, $2);
 	} else {
 		// hot update
-		reload(${id}, proxyComponent);
+		$2 = reload(${id}, $2);
 	}
 }
 
-export default proxyComponent;
+
+export default $2;
 `;
 
 	return code.replace(/(export default ([^;]*));/, replacement);

--- a/lib/hot-api.js
+++ b/lib/hot-api.js
@@ -18,7 +18,15 @@ export function register(id, component) {
 		instances: []
 	});
 
-	return createProxy(id);
+	//create the proxy itself
+	const proxy = createProxy(id);
+
+	//patch the registry record with proxy constructor
+	const record = Registry.get(id);
+	record.proxy = proxy;
+	Registry.set(id, record);
+
+	return proxy;
 }
 
 export function reload(id, component) {
@@ -33,8 +41,11 @@ export function reload(id, component) {
 
 	Registry.set(id, record);
 
-	//re-render the proxies
+	//re-render the proxy instances
 	record.instances.slice().forEach(function(instance) {
 		instance && instance._rerender();
 	});
+
+	//return the original proxy constructor that was `register()`-ed
+	return record.proxy;
 }


### PR DESCRIPTION
See ekhaled/svelte-hot-loader#10 for a bit of background.

The problem was... 
While components were wrapped up in a proxy on initial load, after a hot reload only the instances were re-rendered. The wrapped component was never exported.

This works fine for nested components. But, for top-level components, it caused webpack to update its reference of the component to the unwrapped component.

When the top-level component was being mounted later on, using `new Component`, the unwrapped component was mounted.
The unwrapped component has no idea how to handle hot reloads... therefore it wasn't responding to HMR updates.

This PR fixes the immediate problem. 
But it has opened my eyes to problems that I might have to tackle in the future.

**For example:** 
When a new component comes in via hot reload, it's proxy needs to update it's pointers to the raw component's static properties, and static methods. 
Right now these pointers/references are directed to the original.

For now, I think it's ok to expect people to do a full reload if they modify static properties and/or methods of a component.