### PR TITLE
Allow any version of svelte greater than 1.44.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "svelte": "^1.60.0"
   },
   "peerDependencies": {
-    "svelte": "^1.44.0"
+    "svelte": ">1.44.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently there's ugly warnings in sapper because svelte-loader believes it is incompatible with sapper 2. It does not appear to be _at all_ incompatible with v2 though. Currently I'm ignoring the irritating warning.

The problem is that there are really two versions to keep track of in svelte:

 1. The compiler API. (The part that matters for svelte-loader)
 2. The svelte language itself. (The part that got svelte bumped to v2).

Both are interesting. Both need to be tracked. But they should probably be tracked in separate packages to allow more specific dependencies. (So, for example, you could lock into the compiler API at `^1.44.0` but the language at '2.x').