### PR TITLE
Escape virtual css file path for Windows support

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,8 +117,9 @@ module.exports = function(source, map) {
 				/\.[^/.]+$/,
 				`.svelte.css`
 			);
+
 			css.code += '\n/*# sourceMappingURL=' + css.map.toUrl() + '*/';
-			js.code = js.code + `\nimport '${cssFilepath}';\n`;
+			js.code = js.code + `\nimport '${posixify(cssFilepath)}';\n`;
 
 			if (virtualModules) {
 				virtualModules.writeModule(cssFilepath, css.code);


### PR DESCRIPTION
Currently, the `import '<filePath>.js'` is unescaped in windows environments:

`'C:\project\style.svelte.css'` is treated as `C:projectstyle.svelte.css`