### PR TITLE
[#63] check for compiler.hooks

### DIFF
--- a/lib/virtual.js
+++ b/lib/virtual.js
@@ -32,10 +32,16 @@ function VirtualModulesPlugin(compiler) {
 		};
 	}
 
-	compiler.hooks.watchRun.tapAsync('VirtualModulesPlugin', (watcher, callback) => {
+	const watchRunHook = (watcher, callback) => {
 		this._watcher = watcher.compiler || watcher;
 		callback();
-	});
+	};
+
+	if (compiler.hooks) {
+		compiler.hooks.watchRun.tapAsync('VirtualModulesPlugin', watchRunHook);
+	} else {
+		compiler.plugin('watch-run', watchRunHook);
+	}
 }
 
 VirtualModulesPlugin.prototype.writeModule = function(filePath, contents) {


### PR DESCRIPTION
Fixes #63 

This PR makes a small refactor that checks for the presence of `compiler.hooks` before tapping in the `watch-run` hook. This is necessary to support versions of previous to [`webpack@4.0.0`](https://github.com/webpack/webpack/releases/tag/v4.0.0). When `compiler.hooks` are not available, this change will fall back to the original `compiler.plugin('watch-run', () => {});` approach that is expected for these earlier version of `webpack`.

Surely it would be nice for everybody to just update `webpack` and see the problem go away, but it just isn't always that simple in the big business world.