### PR TITLE
Get svelte-loader working with v3 alpha

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 const { basename, extname, relative } = require('path');
-const { compile, preprocess } = require('svelte/compiler');
 const { getOptions } = require('loader-utils');
 const VirtualModules = require('./lib/virtual');
 const requireRelative = require('require-relative');
@@ -8,6 +7,9 @@ const hotApi = require.resolve('./lib/hot-api.js');
 
 const { version } = require('svelte/package.json');
 const major_version = +version[0];
+const { compile, preprocess } = major_version >= 3
+	? require('svelte/compiler')
+	: require('svelte');
 
 function makeHot(id, code, hotOptions) {
 	const options = JSON.stringify(hotOptions);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1249,9 +1249,9 @@
       "dev": true
     },
     "svelte": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-2.9.5.tgz",
-      "integrity": "sha512-/bfZ+jjI6aCYakMAkzSOnNLBeIpgCgzNRHRVoL5SC9nBdx5R0cxH20h6A7sjl1w5PR3KvQ9YEovGZoiYKF1/TQ==",
+      "version": "3.0.0-alpha12",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.0.0-alpha12.tgz",
+      "integrity": "sha512-Z0eHReVfxHCCS0sd5mOwcEn7wljxMCbh3G+ZYIIOAf88M3H1Mx/c7vBlIRigpU5xZDnNavLJBSFHAlnyEACFAQ==",
       "dev": true
     },
     "svelte-dev-helper": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1249,9 +1249,9 @@
       "dev": true
     },
     "svelte": {
-      "version": "3.0.0-alpha12",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.0.0-alpha12.tgz",
-      "integrity": "sha512-Z0eHReVfxHCCS0sd5mOwcEn7wljxMCbh3G+ZYIIOAf88M3H1Mx/c7vBlIRigpU5xZDnNavLJBSFHAlnyEACFAQ==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-2.16.0.tgz",
+      "integrity": "sha512-1x1zCZpNnuwQdH+9tTeM0QYv33TVEFIxrrd88Mv80EcaomIlA9IvFLIThc8OFsCMHwrjllbIRNmsVfwlOxI7MA==",
       "dev": true
     },
     "svelte-dev-helper": {

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "mocha": "^5.2.0",
     "sinon": "^6.1.5",
     "sinon-chai": "^3.2.0",
-    "svelte": "alpha"
+    "svelte": "^2.9.5"
   },
   "peerDependencies": {
-    "svelte": "alpha"
+    "svelte": ">1.44.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "mocha": "^5.2.0",
     "sinon": "^6.1.5",
     "sinon-chai": "^3.2.0",
-    "svelte": "^2.9.5"
+    "svelte": "alpha"
   },
   "peerDependencies": {
-    "svelte": ">1.44.0"
+    "svelte": "alpha"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This makes some small changes to get `svelte-loader` working with the current v3 alpha branch.

## Todo

- [x] Fix failing tests