### PR TITLE
fix: 🐛 prevent css injection if emitCss is set to true

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,6 +131,8 @@ module.exports = function(source, map) {
 		if (!pluginOptions[option]) compileOptions[option] = options[option];
 	}
 
+	if (options.emitCss) compileOptions.css = false;
+
 	deprecatePreprocessOptions(options);
 	options.preprocess.filename = compileOptions.filename;
 


### PR DESCRIPTION
Before [these changes](https://github.com/sveltejs/svelte-loader/commit/f919ccf0c9b9d3d615269f54c33ff3f3086ef1d0#diff-168726dbe96b3ce427e7fedce31bb0bcL113), when `emitCss` was `true`, the compiler option `css` was automatically set to `false`.