### PR TITLE
Some input filesystems don't implement purge

### DIFF
--- a/lib/virtual.js
+++ b/lib/virtual.js
@@ -12,7 +12,9 @@ function VirtualModulesPlugin(compiler) {
 		var originalPurge = compiler.inputFileSystem.purge;
 
 		compiler.inputFileSystem.purge = function() {
-			originalPurge.call(this, arguments);
+			if (originalPurge) {
+				originalPurge.call(this, arguments);
+			}
 			if (this._virtualFiles) {
 				Object.keys(this._virtualFiles).forEach(
 					function(file) {


### PR DESCRIPTION
If the input filesystem doesn't have purge, the current code throws.
```
C:\dev\nativescript\svelte-ns-testapp\node_modules\svelte-loader\lib\virtual.js:15
                        originalPurge.call(this, arguments);
                                      ^

TypeError: Cannot read property 'call' of undefined
    at Object.VirtualModulesPlugin.compiler.inputFileSystem.purge (C:\dev\nativescript\svelte-ns-testapp\node_modules\svelte-loader\lib\virtual.js:15:18)
    at Compiler.purgeInputFileSystem (C:\dev\nativescript\svelte-ns-testapp\node_modules\webpack\lib\Compiler.js:302:25)
    at compilerCallback (C:\dev\nativescript\svelte-ns-testapp\node_modules\webpack-cli\bin\cli.js:483:15)
```
I encountered this problem. This commit solved the problem