### PR TITLE
Add npm install instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@
 A [webpack](https://webpack.js.org) loader for [svelte](https://svelte.technology).
 
 
+## Install
+
+```
+npm install --save svelte svelte-loader
+```
+
+
 ## Usage
 
 Configure inside your `webpack.config.js`:


### PR DESCRIPTION
**What?** Add install instructions.
**Why?** I wasn't paying attention when I installed the loader, and didn't realise `svelte` was a peer dependency. This should make it more clear :v: