### PR TITLE
fix: assert the option exists before sending it to the compiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ module.exports = function(source, map) {
 	}
 
 	for (const option in options) {
-		if (!pluginOptions[option]) compileOptions[option] = options[option];
+		if (option in pluginOptions && !pluginOptions[option]) compileOptions[option] = options[option];
 	}
 
 	if (options.emitCss) compileOptions.css = false;


### PR DESCRIPTION
Using https://github.com/JeffreyWay/laravel-mix, options like `context` were sent to the compiler : it must not