### PR TITLE
Fix hotReload example

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,11 @@ Hot reloading is turned off by default, you can turn it on using the `hotReload`
       {
         test: /\.(html|svelte)$/,
         exclude: /node_modules/,
-        use: 'svelte-loader',
-        options: {
-          hotReload: true
+        use: {
+          loader: 'svelte-loader',
+          options: {
+            hotReload: true
+          }
         }
       }
       ...


### PR DESCRIPTION
Webpack gave me an error when I tried the hotReload example:

```
Error: options/query provided without loader (use loader + options) in {
  "test": {},
  "exclude": {},
  "use": [
    "svelte-loader"
  ],
  "options": {
    "hotReload": true
  }
}
```

I've fixed it so it'll work, with `loader` and `options` inside a `use` block.