### PR TITLE
don't pass `onwarn` to compiler itself in Svelte 3

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const pluginOptions = {
 	emitCss: true,
 
 	// legacy
+	onwarn: true,
 	shared: true,
 	style: true,
 	script: true,


### PR DESCRIPTION
Fixes #104. We appear to have been already correctly handling the warning array returned by the compiler, but we were neglecting to remove `onwarn` from the options we passed to the compiler.