### PR TITLE
update travis config to run on current Node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-- '9'
 - '8'
-- '6'
+- '10'
+- '12'
 
 script:
 - npm run all


### PR DESCRIPTION
Travis was running on 6, 8, and 9.  This was failing because the compiler code uses `async` in the preprocess function. This updates travis to use 8, 10, and 12.