### PR TITLE
resolves svelte from node entrypoint & add support for overriding svelte location - fixes #109

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ module.exports = function(source, map) {
 	const virtualModules = virtualModuleInstances.get(this._compiler);
 
 	this.cacheable();
-	
+
 	const options = Object.assign({}, getOptions(this));
 	const callback = this.async();
 

--- a/index.js
+++ b/index.js
@@ -4,11 +4,11 @@ const VirtualModules = require('./lib/virtual');
 
 const hotApi = require.resolve('./lib/hot-api.js');
 
-const { version } = require('svelte/package.json');
-const major_version = +version[0];
-const { compile, preprocess } = major_version >= 3
-	? require('svelte/compiler')
-	: require('svelte');
+const {
+	major_version,
+	compile,
+	preprocess,
+} = require('./lib/resolve-svelte');
 
 const pluginOptions = {
 	externalDependencies: true,

--- a/lib/resolve-svelte.js
+++ b/lib/resolve-svelte.js
@@ -1,10 +1,34 @@
-const { version } = require.main.require('svelte/package.json');
+const path = require('path');
+
+// Svelte location can be overriden by env variable. This can be needed
+// to use some external tools targetting a whole app, during development
+// of svelte-loader.
+
+const resolveSvelte = () => {
+	const { SVELTE } = process.env;
+	if (SVELTE) {
+		const ensureAbsolute = name =>
+			path.isAbsolute(name) ? name : path.resolve(process.cwd(), name);
+		return {
+			req: require,
+			svelte: ensureAbsolute(SVELTE),
+		};
+	} else {
+		return {
+			req: require.main.require.bind(require.main),
+			svelte: 'svelte',
+		};
+	}
+};
+
+const { req, svelte } = resolveSvelte();
+
+const { version } = req(`${svelte}/package.json`);
 
 const major_version = +version[0];
 
-const { compile, preprocess } = major_version >= 3
-	? require.main.require('svelte/compiler')
-	: require.main.require('svelte');
+const { compile, preprocess } =
+	major_version >= 3 ? req(`${svelte}/compiler`) : req(svelte);
 
 module.exports = {
 	major_version,

--- a/lib/resolve-svelte.js
+++ b/lib/resolve-svelte.js
@@ -1,0 +1,13 @@
+const { version } = require('svelte/package.json');
+
+const major_version = +version[0];
+
+const { compile, preprocess } = major_version >= 3
+	? require('svelte/compiler')
+	: require('svelte');
+
+module.exports = {
+	major_version,
+	compile,
+	preprocess,
+};

--- a/lib/resolve-svelte.js
+++ b/lib/resolve-svelte.js
@@ -1,10 +1,10 @@
-const { version } = require('svelte/package.json');
+const { version } = require.main.require('svelte/package.json');
 
 const major_version = +version[0];
 
 const { compile, preprocess } = major_version >= 3
-	? require('svelte/compiler')
-	: require('svelte');
+	? require.main.require('svelte/compiler')
+	: require.main.require('svelte');
 
 module.exports = {
 	major_version,


### PR DESCRIPTION
Uses `require.main.require` to resolve svelte from app entrypoint. This will use app's own `svelte` even when using a symlinked `svelte-loader`.

The last commit additionaly allows to provide svelte location directly with an env variable. This can be required by some external tools targeting `svelte-loader`, but have their own entrypoint outside of the main app (full disclosure: I need it for [`svelte-hmr-spec`](https://github.com/rixo/svelte-hmr-spec)).