### PR TITLE
Add JSDoc for VirtualModulesPlugin constructor

### DIFF
--- a/lib/virtual.js
+++ b/lib/virtual.js
@@ -5,6 +5,9 @@ var inode = 45000000;
 // Adapted from https://github.com/sysgears/webpack-virtual-modules
 // MIT Licensed https://github.com/sysgears/webpack-virtual-modules/blob/master/LICENSE
 
+/**
+ * @param {Compiler} compiler - the webpack compiler
+ */
 function VirtualModulesPlugin(compiler) {
 	this.compiler = compiler;
 


### PR DESCRIPTION
Clarify that the compiler is the webpack compiler and not the svelte compiler