### PR TITLE
fix: made VirtualStats compatible with Node 6/8/10/12/14

### DIFF
--- a/lib/virtual.js
+++ b/lib/virtual.js
@@ -48,19 +48,24 @@ function VirtualModulesPlugin(compiler) {
 
 VirtualModulesPlugin.prototype.writeModule = function(filePath, contents) {
 	var len = contents ? contents.length : 0;
-	var time = Date.now();
+	var time = new Date();
+	var timeMs = time.getTime();
 
 	var stats = new VirtualStats({
 		dev: 8675309,
+		ino: inode++,
+		mode: 33188,
 		nlink: 0,
 		uid: 1000,
 		gid: 1000,
 		rdev: 0,
-		blksize: 4096,
-		ino: inode++,
-		mode: 33188,
 		size: len,
+		blksize: 4096,
 		blocks: Math.floor(len / 4096),
+		atimeMs: timeMs,
+		mtimeMs: timeMs,
+		ctimeMs: timeMs,
+		birthtimeMs: timeMs,
 		atime: time,
 		mtime: time,
 		ctime: time,


### PR DESCRIPTION
VirtualStats was missing millisecond variables and incorrectly provided time value as milliseconds, when Node provides it as Date object - https://nodejs.org/docs/latest-v12.x/api/fs.html#fs_class_fs_stats.

This made webpack crash periodically when using cache-loader in front of svelte-loader.