### PR TITLE
Update VirtualModulesPlugin from upstream

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,42 @@
+svelte-loader is licensed under the MIT license:
+Copyright (c) 2020 svelte-loader contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+lib/virtual.js and lib/virtual-stats.js also contain code licensed under the
+MIT license:
+Copyright (c) 2017 SysGears
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/index.js
+++ b/index.js
@@ -178,6 +178,6 @@ module.exports = function(source, map) {
 	}, err => callback(err)).catch(err => {
 		// wrap error to provide correct
 		// context when logging to console
-		callback(new Error(`${err.name}: ${err.toString()}`));
+		callback(new Error(`${err.name || "Error"}: ${err.toString()}`));
 	});
 };

--- a/index.js
+++ b/index.js
@@ -178,6 +178,6 @@ module.exports = function(source, map) {
 	}, err => callback(err)).catch(err => {
 		// wrap error to provide correct
 		// context when logging to console
-		callback(new Error(`${err.name || "Error"}: ${err.toString()}`));
+		callback(new Error(`${err.name || 'Error'}: ${err.toString()}`));
 	});
 };

--- a/lib/virtual-stats.js
+++ b/lib/virtual-stats.js
@@ -1,3 +1,5 @@
+// Adapted from https://github.com/sysgears/webpack-virtual-modules
+
 /**
  * Used to cache a stats object for the virtual file.
  * Extracted from the `mock-fs` package.

--- a/lib/virtual-stats.js
+++ b/lib/virtual-stats.js
@@ -14,7 +14,7 @@
 
 'use strict';
 
-var constants = require('constants');
+const constants = require('constants');
 
 /**
  * Create a new stats object.
@@ -22,7 +22,7 @@ var constants = require('constants');
  * @constructor
  */
 function VirtualStats(config) {
-	for (var key in config) {
+	for (const key in config) {
 		if (!config.hasOwnProperty(key)) {
 			continue;
 		}

--- a/lib/virtual.js
+++ b/lib/virtual.js
@@ -1,9 +1,26 @@
+// Adapted from https://github.com/sysgears/webpack-virtual-modules
+
 var VirtualStats = require('./virtual-stats');
+var path = require("path");
 
 var inode = 45000000;
 
-// Adapted from https://github.com/sysgears/webpack-virtual-modules
-// MIT Licensed https://github.com/sysgears/webpack-virtual-modules/blob/master/LICENSE
+function createWebpackData(result) {
+	return (function(backendOrStorage) {
+		// In Webpack v5, this variable is a "Backend", and has the data stored in a field
+		// _data. In V4, the `_` prefix isn't present.
+		if (backendOrStorage._data) {
+			const curLevelIdx = backendOrStorage._currentLevel;
+			const curLevel = backendOrStorage._levels[curLevelIdx];
+			return {
+				result: this.result,
+				level: curLevel
+			};
+		}
+		// Webpack 4
+		return [null, result];
+	}).bind({ result: result });
+}
 
 /**
  * @param {Compiler} compiler - the webpack compiler
@@ -16,29 +33,83 @@ function VirtualModulesPlugin(compiler) {
 
 		compiler.inputFileSystem.purge = function() {
 			if (originalPurge) {
-				originalPurge.call(this, arguments);
+				originalPurge.apply(this, arguments);
 			}
 			if (this._virtualFiles) {
-				Object.keys(this._virtualFiles).forEach(
-					function(file) {
-						var data = this._virtualFiles[file];
-						setData(this._statStorage, file, [null, data.stats]);
-						setData(this._readFileStorage, file, [null, data.contents]);
-					}.bind(this)
-				);
+				Object.keys(this._virtualFiles).forEach(function(file) {
+					var data = this._virtualFiles[file];
+					this._writeVirtualFile(file, data.stats, data.contents);
+				}.bind(this));
 			}
 		};
 
 		compiler.inputFileSystem._writeVirtualFile = function(file, stats, contents) {
+			const statStorage = getStatStorage(this);
+			const fileStorage = getFileStorage(this);
+			const readDirStorage = getReadDirBackend(this);
 			this._virtualFiles = this._virtualFiles || {};
 			this._virtualFiles[file] = { stats: stats, contents: contents };
-			setData(this._statStorage, file, [null, stats]);
-			setData(this._readFileStorage, file, [null, contents]);
+			setData(statStorage, file, createWebpackData(stats));
+			setData(fileStorage, file, createWebpackData(contents));
+			compiler.fileTimestamps instanceof Map &&
+				compiler.fileTimestamps.set(file, +stats.mtime);
+			var segments = file.split(/[\\/]/);
+			var count = segments.length - 1;
+			var minCount = segments[0] ? 1 : 0;
+			while (count > minCount) {
+				var dir = segments.slice(0, count).join(path.sep) || path.sep;
+				try {
+					compiler.inputFileSystem.readdirSync(dir);
+				} catch (e) {
+					var time = new Date();
+					var timeMs = time.getTime();
+					var dirStats = new VirtualStats({
+						dev: 8675309,
+						nlink: 0,
+						uid: 1000,
+						gid: 1000,
+						rdev: 0,
+						blksize: 4096,
+						ino: inode++,
+						mode: 16877,
+						size: stats.size,
+						blocks: Math.floor(stats.size / 4096),
+						atimeMs: timeMs,
+						mtimeMs: timeMs,
+						ctimeMs: timeMs,
+						birthtimeMs: timeMs,
+						atime: time,
+						mtime: time,
+						ctime: time,
+						birthtime: time
+					});
+					setData(readDirStorage, dir, createWebpackData([]));
+					setData(statStorage, dir, createWebpackData(dirStats));
+				}
+				var dirData = getData(getReadDirBackend(this), dir);
+				// Webpack v4 returns an array, webpack v5 returns an object
+				dirData = dirData[1] || dirData.result;
+				var filename = segments[count];
+				if (dirData.indexOf(filename) < 0) {
+					var files = dirData.concat([filename]).sort();
+					setData(getReadDirBackend(this), dir, createWebpackData(files));
+				} else {
+					break;
+				}
+				count--;
+			}
 		};
 	}
 
 	const watchRunHook = (watcher, callback) => {
 		this._watcher = watcher.compiler || watcher;
+		const virtualFiles = compiler.inputFileSystem._virtualFiles;
+		if (virtualFiles) {
+			Object.keys(virtualFiles).forEach(function(file) {
+				compiler.fileTimestamps instanceof Map &&
+				compiler.fileTimestamps.set(file, +virtualFiles[file].stats.mtime);
+			});
+		}
 		callback();
 	};
 
@@ -75,14 +146,81 @@ VirtualModulesPlugin.prototype.writeModule = function(filePath, contents) {
 		birthtime: time
 	});
 
+	// When using the WatchIgnorePlugin (https://github.com/webpack/webpack/blob/52184b897f40c75560b3630e43ca642fcac7e2cf/lib/WatchIgnorePlugin.js),
+	// the original watchFileSystem is stored in `wfs`. The following "unwraps" the ignoring
+	// wrappers, giving us access to the "real" watchFileSystem.
+	let finalWatchFileSystem = this._watcher && this._watcher.watchFileSystem;
+
+	while (finalWatchFileSystem && finalWatchFileSystem.wfs) {
+		finalWatchFileSystem = finalWatchFileSystem.wfs;
+	}
 	this.compiler.inputFileSystem._writeVirtualFile(filePath, stats, contents);
 };
 
-function setData(storage, key, value) {
-	if (storage.data instanceof Map) {
-		storage.data.set(key, value);
+function getData(storage, key) {
+	// Webpack 5
+	if (storage._data instanceof Map) {
+		return storage._data.get(key);
+	} else if (storage._data) {
+		return storage.data[key];
+	} else if (storage.data instanceof Map) {
+		// Webpack v4
+		return storage.data.get(key);
 	} else {
-		storage.data[key] = value;
+		return storage.data[key];
+	}
+}
+
+function setData(backendOrStorage, key, valueFactory) {
+	const value = valueFactory(backendOrStorage);
+
+	// Webpack v5
+	if (backendOrStorage._data instanceof Map) {
+		backendOrStorage._data.set(key, value);
+	} else if (backendOrStorage._data) {
+		backendOrStorage.data[key] = value;
+	} else if (backendOrStorage.data instanceof Map) {
+		// Webpack 4
+		backendOrStorage.data.set(key, value);
+		backendOrStorage.data.set(key, value);
+	} else {
+		backendOrStorage.data[key] = value;
+		backendOrStorage.data[key] = value;
+	}
+}
+
+function getStatStorage(fileSystem) {
+	if (fileSystem._statStorage) {
+		// Webpack v4
+		return fileSystem._statStorage;
+	} else if (fileSystem._statBackend) {
+		// webpack v5
+		return fileSystem._statBackend;
+	} else {
+		// Unknown version?
+		throw new Error("Couldn't find a stat storage");
+	}
+}
+
+function getFileStorage(fileSystem) {
+	if (fileSystem._readFileStorage) {
+		// Webpack v4
+		return fileSystem._readFileStorage;
+	} else if (fileSystem._readFileBackend) {
+		// Webpack v5
+		return fileSystem._readFileBackend;
+	} else {
+		throw new Error("Couldn't find a readFileStorage");
+	}
+}
+
+function getReadDirBackend(fileSystem) {
+	if (fileSystem._readdirBackend) {
+		return fileSystem._readdirBackend;
+	} else if (fileSystem._readdirStorage) {
+		return fileSystem._readdirStorage;
+	} else {
+		throw new Error("Couldn't find a readDirStorage from Webpack Internals");
 	}
 }
 

--- a/lib/virtual.js
+++ b/lib/virtual.js
@@ -1,7 +1,7 @@
 // Adapted from https://github.com/sysgears/webpack-virtual-modules
 
 var VirtualStats = require('./virtual-stats');
-var path = require("path");
+var path = require('path');
 
 var inode = 45000000;
 
@@ -198,7 +198,7 @@ function getStatStorage(fileSystem) {
 		return fileSystem._statBackend;
 	} else {
 		// Unknown version?
-		throw new Error("Couldn't find a stat storage");
+		throw new Error('Couldn\'t find a stat storage');
 	}
 }
 
@@ -210,7 +210,7 @@ function getFileStorage(fileSystem) {
 		// Webpack v5
 		return fileSystem._readFileBackend;
 	} else {
-		throw new Error("Couldn't find a readFileStorage");
+		throw new Error('Couldn\'t find a readFileStorage');
 	}
 }
 
@@ -220,7 +220,7 @@ function getReadDirBackend(fileSystem) {
 	} else if (fileSystem._readdirStorage) {
 		return fileSystem._readdirStorage;
 	} else {
-		throw new Error("Couldn't find a readDirStorage from Webpack Internals");
+		throw new Error('Couldn\'t find a readDirStorage from Webpack Internals');
 	}
 }
 

--- a/lib/virtual.js
+++ b/lib/virtual.js
@@ -22,6 +22,10 @@ function createWebpackData(result) {
 	}).bind({ result: result });
 }
 
+function getModulePath(filePath, compiler) {
+	return path.isAbsolute(filePath) ? filePath : path.join(compiler.context, filePath);
+}
+
 /**
  * @param {Compiler} compiler - the webpack compiler
  */
@@ -51,8 +55,6 @@ function VirtualModulesPlugin(compiler) {
 			this._virtualFiles[file] = { stats: stats, contents: contents };
 			setData(statStorage, file, createWebpackData(stats));
 			setData(fileStorage, file, createWebpackData(contents));
-			compiler.fileTimestamps instanceof Map &&
-				compiler.fileTimestamps.set(file, +stats.mtime);
 			var segments = file.split(/[\\/]/);
 			var count = segments.length - 1;
 			var minCount = segments[0] ? 1 : 0;
@@ -103,13 +105,6 @@ function VirtualModulesPlugin(compiler) {
 
 	const watchRunHook = (watcher, callback) => {
 		this._watcher = watcher.compiler || watcher;
-		const virtualFiles = compiler.inputFileSystem._virtualFiles;
-		if (virtualFiles) {
-			Object.keys(virtualFiles).forEach(function(file) {
-				compiler.fileTimestamps instanceof Map &&
-				compiler.fileTimestamps.set(file, +virtualFiles[file].stats.mtime);
-			});
-		}
 		callback();
 	};
 
@@ -145,6 +140,7 @@ VirtualModulesPlugin.prototype.writeModule = function(filePath, contents) {
 		ctime: time,
 		birthtime: time
 	});
+	var modulePath = getModulePath(filePath, this.compiler);
 
 	// When using the WatchIgnorePlugin (https://github.com/webpack/webpack/blob/52184b897f40c75560b3630e43ca642fcac7e2cf/lib/WatchIgnorePlugin.js),
 	// the original watchFileSystem is stored in `wfs`. The following "unwraps" the ignoring
@@ -155,6 +151,27 @@ VirtualModulesPlugin.prototype.writeModule = function(filePath, contents) {
 		finalWatchFileSystem = finalWatchFileSystem.wfs;
 	}
 	this.compiler.inputFileSystem._writeVirtualFile(filePath, stats, contents);
+	if (finalWatchFileSystem &&
+		(finalWatchFileSystem.watcher.fileWatchers.size ||
+			finalWatchFileSystem.watcher.fileWatchers.length)
+	) {
+		var fileWatchers = finalWatchFileSystem.watcher.fileWatchers instanceof Map ?
+			Array.from(finalWatchFileSystem.watcher.fileWatchers.values()) :
+			finalWatchFileSystem.watcher.fileWatchers;
+		fileWatchers.forEach(function(fileWatcher) {
+			if (fileWatcher.path === modulePath) {
+				delete fileWatcher.directoryWatcher._cachedTimeInfoEntries;
+				fileWatcher.directoryWatcher.setFileTime(
+					filePath,
+					time,
+					false,
+					false,
+					null
+				);
+				fileWatcher.emit("change", time, null);
+			}
+		});
+	}
 };
 
 function getData(storage, key) {

--- a/lib/virtual.js
+++ b/lib/virtual.js
@@ -58,6 +58,7 @@ function VirtualModulesPlugin(compiler) {
 			const segments = file.split(/[\\/]/);
 			let count = segments.length - 1;
 			const minCount = segments[0] ? 1 : 0;
+			// create directories for each segment (to prevent files not being in a directory)
 			while (count > minCount) {
 				const dir = segments.slice(0, count).join(path.sep) || path.sep;
 				try {
@@ -123,7 +124,7 @@ VirtualModulesPlugin.prototype.writeModule = function(filePath, contents) {
 	const stats = new VirtualStats({
 		dev: 8675309,
 		ino: inode++,
-		mode: 33188,
+		mode: 16877,
 		nlink: 0,
 		uid: 1000,
 		gid: 1000,
@@ -175,17 +176,11 @@ VirtualModulesPlugin.prototype.writeModule = function(filePath, contents) {
 };
 
 function getData(storage, key) {
-	// Webpack 5
-	if (storage._data instanceof Map) {
-		return storage._data.get(key);
-	} else if (storage._data) {
-		return storage.data[key];
-	} else if (storage.data instanceof Map) {
-		// Webpack v4
+	const data = storage._data /* webpack 5 */ || storage.data /* webpack 4 */;
+	if (data instanceof Map) {
 		return storage.data.get(key);
-	} else {
-		return storage.data[key];
 	}
+	return data.data[key];
 }
 
 function setData(backendOrStorage, key, valueFactory) {

--- a/lib/virtual.js
+++ b/lib/virtual.js
@@ -198,7 +198,7 @@ function getStatStorage(fileSystem) {
 		return fileSystem._statBackend;
 	} else {
 		// Unknown version?
-		throw new Error('Couldn\'t find a stat storage');
+		throw new Error("Couldn't find a stat storage");
 	}
 }
 
@@ -210,7 +210,7 @@ function getFileStorage(fileSystem) {
 		// Webpack v5
 		return fileSystem._readFileBackend;
 	} else {
-		throw new Error('Couldn\'t find a readFileStorage');
+		throw new Error("Couldn't find a readFileStorage");
 	}
 }
 
@@ -220,7 +220,7 @@ function getReadDirBackend(fileSystem) {
 	} else if (fileSystem._readdirStorage) {
 		return fileSystem._readdirStorage;
 	} else {
-		throw new Error('Couldn\'t find a readDirStorage from Webpack Internals');
+		throw new Error("Couldn't find a readDirStorage from Webpack Internals");
 	}
 }
 

--- a/lib/virtual.js
+++ b/lib/virtual.js
@@ -1,9 +1,9 @@
 // Adapted from https://github.com/sysgears/webpack-virtual-modules
 
-var VirtualStats = require('./virtual-stats');
-var path = require('path');
+const VirtualStats = require('./virtual-stats');
+const path = require('path');
 
-var inode = 45000000;
+let inode = 45000000;
 
 function createWebpackData(result) {
 	return (function(backendOrStorage) {
@@ -33,7 +33,7 @@ function VirtualModulesPlugin(compiler) {
 	this.compiler = compiler;
 
 	if (!compiler.inputFileSystem._writeVirtualFile) {
-		var originalPurge = compiler.inputFileSystem.purge;
+		const originalPurge = compiler.inputFileSystem.purge;
 
 		compiler.inputFileSystem.purge = function() {
 			if (originalPurge) {
@@ -41,7 +41,7 @@ function VirtualModulesPlugin(compiler) {
 			}
 			if (this._virtualFiles) {
 				Object.keys(this._virtualFiles).forEach(function(file) {
-					var data = this._virtualFiles[file];
+					const data = this._virtualFiles[file];
 					this._writeVirtualFile(file, data.stats, data.contents);
 				}.bind(this));
 			}
@@ -55,17 +55,17 @@ function VirtualModulesPlugin(compiler) {
 			this._virtualFiles[file] = { stats: stats, contents: contents };
 			setData(statStorage, file, createWebpackData(stats));
 			setData(fileStorage, file, createWebpackData(contents));
-			var segments = file.split(/[\\/]/);
-			var count = segments.length - 1;
-			var minCount = segments[0] ? 1 : 0;
+			const segments = file.split(/[\\/]/);
+			let count = segments.length - 1;
+			const minCount = segments[0] ? 1 : 0;
 			while (count > minCount) {
-				var dir = segments.slice(0, count).join(path.sep) || path.sep;
+				const dir = segments.slice(0, count).join(path.sep) || path.sep;
 				try {
 					compiler.inputFileSystem.readdirSync(dir);
 				} catch (e) {
-					var time = new Date();
-					var timeMs = time.getTime();
-					var dirStats = new VirtualStats({
+					const time = new Date();
+					const timeMs = time.getTime();
+					const dirStats = new VirtualStats({
 						dev: 8675309,
 						nlink: 0,
 						uid: 1000,
@@ -88,12 +88,12 @@ function VirtualModulesPlugin(compiler) {
 					setData(readDirStorage, dir, createWebpackData([]));
 					setData(statStorage, dir, createWebpackData(dirStats));
 				}
-				var dirData = getData(getReadDirBackend(this), dir);
+				let dirData = getData(getReadDirBackend(this), dir);
 				// Webpack v4 returns an array, webpack v5 returns an object
 				dirData = dirData[1] || dirData.result;
-				var filename = segments[count];
+				const filename = segments[count];
 				if (dirData.indexOf(filename) < 0) {
-					var files = dirData.concat([filename]).sort();
+					const files = dirData.concat([filename]).sort();
 					setData(getReadDirBackend(this), dir, createWebpackData(files));
 				} else {
 					break;
@@ -116,11 +116,11 @@ function VirtualModulesPlugin(compiler) {
 }
 
 VirtualModulesPlugin.prototype.writeModule = function(filePath, contents) {
-	var len = contents ? contents.length : 0;
-	var time = new Date();
-	var timeMs = time.getTime();
+	const len = contents ? contents.length : 0;
+	const time = new Date();
+	const timeMs = time.getTime();
 
-	var stats = new VirtualStats({
+	const stats = new VirtualStats({
 		dev: 8675309,
 		ino: inode++,
 		mode: 33188,
@@ -140,7 +140,7 @@ VirtualModulesPlugin.prototype.writeModule = function(filePath, contents) {
 		ctime: time,
 		birthtime: time
 	});
-	var modulePath = getModulePath(filePath, this.compiler);
+	const modulePath = getModulePath(filePath, this.compiler);
 
 	// When using the WatchIgnorePlugin (https://github.com/webpack/webpack/blob/52184b897f40c75560b3630e43ca642fcac7e2cf/lib/WatchIgnorePlugin.js),
 	// the original watchFileSystem is stored in `wfs`. The following "unwraps" the ignoring
@@ -155,7 +155,7 @@ VirtualModulesPlugin.prototype.writeModule = function(filePath, contents) {
 		(finalWatchFileSystem.watcher.fileWatchers.size ||
 			finalWatchFileSystem.watcher.fileWatchers.length)
 	) {
-		var fileWatchers = finalWatchFileSystem.watcher.fileWatchers instanceof Map ?
+		const fileWatchers = finalWatchFileSystem.watcher.fileWatchers instanceof Map ?
 			Array.from(finalWatchFileSystem.watcher.fileWatchers.values()) :
 			finalWatchFileSystem.watcher.fileWatchers;
 		fileWatchers.forEach(function(fileWatcher) {

--- a/lib/virtual.js
+++ b/lib/virtual.js
@@ -26,6 +26,32 @@ function getModulePath(filePath, compiler) {
 	return path.isAbsolute(filePath) ? filePath : path.join(compiler.context, filePath);
 }
 
+function createVirtualStats(len) {
+	const time = new Date();
+	const timeMs = time.getTime();
+
+	return new VirtualStats({
+		dev: 8675309,
+		ino: inode++,
+		mode: 16877,
+		nlink: 0,
+		uid: 1000,
+		gid: 1000,
+		rdev: 0,
+		size: len,
+		blksize: 4096,
+		blocks: Math.floor(len / 4096),
+		atimeMs: timeMs,
+		mtimeMs: timeMs,
+		ctimeMs: timeMs,
+		birthtimeMs: timeMs,
+		atime: time,
+		mtime: time,
+		ctime: time,
+		birthtime: time
+	});
+}
+
 /**
  * @param {Compiler} compiler - the webpack compiler
  */
@@ -64,28 +90,7 @@ function VirtualModulesPlugin(compiler) {
 				try {
 					compiler.inputFileSystem.readdirSync(dir);
 				} catch (e) {
-					const time = new Date();
-					const timeMs = time.getTime();
-					const dirStats = new VirtualStats({
-						dev: 8675309,
-						nlink: 0,
-						uid: 1000,
-						gid: 1000,
-						rdev: 0,
-						blksize: 4096,
-						ino: inode++,
-						mode: 16877,
-						size: stats.size,
-						blocks: Math.floor(stats.size / 4096),
-						atimeMs: timeMs,
-						mtimeMs: timeMs,
-						ctimeMs: timeMs,
-						birthtimeMs: timeMs,
-						atime: time,
-						mtime: time,
-						ctime: time,
-						birthtime: time
-					});
+					const dirStats = createVirtualStats(stats.size);
 					setData(readDirStorage, dir, createWebpackData([]));
 					setData(statStorage, dir, createWebpackData(dirStats));
 				}
@@ -118,29 +123,7 @@ function VirtualModulesPlugin(compiler) {
 
 VirtualModulesPlugin.prototype.writeModule = function(filePath, contents) {
 	const len = contents ? contents.length : 0;
-	const time = new Date();
-	const timeMs = time.getTime();
-
-	const stats = new VirtualStats({
-		dev: 8675309,
-		ino: inode++,
-		mode: 16877,
-		nlink: 0,
-		uid: 1000,
-		gid: 1000,
-		rdev: 0,
-		size: len,
-		blksize: 4096,
-		blocks: Math.floor(len / 4096),
-		atimeMs: timeMs,
-		mtimeMs: timeMs,
-		ctimeMs: timeMs,
-		birthtimeMs: timeMs,
-		atime: time,
-		mtime: time,
-		ctime: time,
-		birthtime: time
-	});
+	const stats = createVirtualStats(len);
 	const modulePath = getModulePath(filePath, this.compiler);
 
 	// When using the WatchIgnorePlugin (https://github.com/webpack/webpack/blob/52184b897f40c75560b3630e43ca642fcac7e2cf/lib/WatchIgnorePlugin.js),
@@ -164,12 +147,12 @@ VirtualModulesPlugin.prototype.writeModule = function(filePath, contents) {
 				delete fileWatcher.directoryWatcher._cachedTimeInfoEntries;
 				fileWatcher.directoryWatcher.setFileTime(
 					filePath,
-					time,
+					stats.birthtime,
 					false,
 					false,
 					null
 				);
-				fileWatcher.emit("change", time, null);
+				fileWatcher.emit("change", stats.birthtime, null);
 			}
 		});
 	}


### PR DESCRIPTION
tl;dr: Webpack 5 support, fixes `TypeError: Cannot read property 'data' of undefined`

This updates the internal VirtualModulesPlugin, which is copied from [`webpack-virtual-modules`](https://github.com/sysgears/webpack-virtual-modules), which was originally added by @kaisermann. These changes allow for using Webpack 5 with `svelte-loader`. The changes of #125, which have also been fixed upstream, have been preserved. See https://github.com/sveltejs/svelte-loader/pull/59#issuecomment-385381444 for the background on why the source code is just copied over instead of added as a dependency. Due to the `svelte-loader` specific changes already in `virtual.js`, I have manually gone through the commit history of [`webpack-virtual-modules`](https://github.com/sysgears/webpack-virtual-modules) and applied relevant changes instead of just copy-pasting the new source code. There is also a small change to `index.js` to prevent the error handling code from itself throwing errors, since that was causing some (now fixed) troubles when debugging my changes.

This also adds in the literal text of the license of [`webpack-virtual-modules`](https://github.com/sysgears/webpack-virtual-modules), to a newly created `LICENSE` file, since "The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software".

Tests and lints pass, and I have verified this works with both Webpack 4 and Webpack 5

[continuation from #132, since GH won't let me re-open it]

Closes https://github.com/sveltejs/svelte-loader/pull/133