### PR TITLE
Document workaround for Svelte errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,14 @@ Configure inside your `webpack.config.js`:
         test: /\.(html|svelte)$/,
         exclude: /node_modules/,
         use: 'svelte-loader'
-      }
+      },
+      // Only include this when using Webpack 5+
+      {
+        test: /node_modules\/svelte\/.*\.mjs$/,
+        resolve: {
+          fullySpecified: false // load Svelte correctly
+        }
+      },
       ...
     ]
   }


### PR DESCRIPTION
In Webpack 5+, this is required to load Svelte correctly, due to what appears to be code generation issues with TypeScript, see https://github.com/microsoft/TypeScript/issues/16577.

This works around that by using telling end users to use [a newly added feature in Webpack 5+](https://webpack.js.org/configuration/module/#resolvefullyspecified), that uses Webpack 4 behavior for resolving module names.

(Webpack 5 is currently already supported when `emitCss` is `false`)