### PR TITLE
feat: expose loader context and virtual write to preprocess

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,11 @@ module.exports = function(source, map) {
 	}
 
 	if (options.emitCss) compileOptions.css = false;
-
+	
+	if (typeof options.preprocess === 'function') {
+		options.preprocess = options.preprocess(this, virtualModules.writeModule.bind(virtualModules));
+	}
+	
 	deprecatePreprocessOptions(options);
 	options.preprocess.filename = compileOptions.filename;
 


### PR DESCRIPTION
👋  Hey folks. Not trying to be presumptuous, but thought this proposal would be best served with a PR. 

This allows the `preprocess` option to be a function that is passed the webpack loader context as well as the virtual `writeModule` method. I don't expect this to be commonly used, but allows for more advanced integration into the webpack build pipeline by preprocessors. 

The impetus for this is trying to add better css-module (and related languages) support for svelte style tags, but this applies to any preprocessor that might need to do further downstream processing of the resulting styles, markup or js. In my case I need to do further coordination with style files _after_ they have been extracted from the svelte file. Basically this requires doing a very similar trick to what svelte-loader does, by removing the style markup, emitting a (non `.css`) file and adding an import to that file to the script portion of the component. This bypasses svelte's styling handling but lets webpack process the file further with additional loaders.

This is helpful for few reasons:
- you don't have to return css that is parsable by svelte's style parser
- you don't have to awkwardly target multiple file extensions in loaders e.g. `.my-css`, and `.svelte.css`

Alternatives to this involve sharing some manner of stateful compiler instance that is passed to both the specific svelte preprocess function and a loader config.

I realize this use-case is hard to articulate, but if it helps there is some prior art for this sort of thing with `postcss-loader`: https://github.com/webpack-contrib/postcss-loader#function I can also point to my local experiments adding support for my css-module light preprocessor if that might help clarify the need.

