### PR TITLE
Add generate option to allow for SSR compilation from webpack.

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,24 @@ const variables = path.resolve('./variables.js');
   }
 ```
 
+### SSR
+
+To build a Svelte component for SSR, pass a `generate` property with a value of "ssr"
+
+```js
+{
+    test: /\.(html|svelte)$/,
+    use: [
+      {
+        loader: 'svelte-loader',
+        options: {
+          generate: "ssr"
+        }
+      }
+    ]
+  }
+```
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -118,6 +118,10 @@ module.exports = function(source, map) {
 		format: options.format || (major_version >= 3 ? 'esm' : 'es')
 	};
 
+	if (options.generate) {
+		compileOptions.generate = options.generate;
+	}
+
 	const handleWarning = warning => this.emitWarning(new Error(warning));
 
 	if (major_version >= 3) {


### PR DESCRIPTION
Right now it doesn't appear as though you can build a Svelte component with webpack that's fit for SSR. One big reason you might want to do that is to take advantage of webpack path resolution, ie 

```
resolve: {
  extensions: [".mjs", ".ts", ".tsx", ".js", ".svelte"],
  modules: [path.resolve("./"), path.resolve("./node_modules")],
```

which allows you to import things from, say, 

```
import { foo } from "app/a/b/c/d/foo.js" 
```

rather than

```
import { foo } from "../../../d/foo.js"
```

This PR exposes the "generate" compile option to the plugin, for this purpose. 