### PR TITLE
Move CI to Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         node-version: [ '8', '10', '12', '14' ]
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest]
     name: Test on Node v${{ matrix.node-version }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         node-version: [ '8', '10', '12', '14' ]
         os: [ubuntu-latest, windows-latest, macOS-latest]
-    name: Test on Node v${{ matrix.node-version }}
+    name: Test on Node v${{ matrix.node-version }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: Setup node

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  Tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node-version: [ '8', '10', '12', '14' ]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    name: Test on Node v${{ matrix.node-version }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run all
+        env:
+          CI: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-node_js:
-- '8'
-- '10'
-- '12'
-- '14'
-
-script:
-- npm run all

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -88,7 +88,7 @@ describe('loader', () => {
 			) {
 				expect(err).to.exist;
 
-				expect(err.message.trim()).to.eql(d`
+				expect(err.message.trim().replace(/\r/g, "")).to.eql(d`
 					ValidationError: A component cannot have a default export (2:1)
 					1: <script>
 					2:   export default {};

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -88,7 +88,7 @@ describe('loader', () => {
 			) {
 				expect(err).to.exist;
 
-				expect(err.message.trim().replace(/\r/g, "")).to.eql(d`
+				expect(err.message.trim().replace(/\r/g, '')).to.eql(d`
 					ValidationError: A component cannot have a default export (2:1)
 					1: <script>
 					2:   export default {};

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -9,7 +9,7 @@ chai.use(sinonChai);
 const { expect } = chai;
 
 function d([str]) {
-	return str.replace(/^\t+/gm, '').replace(/\r/g, "").trim();
+	return str.replace(/^\t+/gm, '').replace(/\r/g, '').trim();
 }
 
 describe('loader', () => {

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -9,7 +9,7 @@ chai.use(sinonChai);
 const { expect } = chai;
 
 function d([str]) {
-	return str.replace(/^\t+/gm, '').trim();
+	return str.replace(/^\t+/gm, '').replace(/\r/g, "").trim();
 }
 
 describe('loader', () => {


### PR DESCRIPTION
Per https://github.com/sveltejs/svelte-loader/pull/140#pullrequestreview-514153012, most Svelte repos are using Github Actions now, so let's use it here too. travis-ci.org is shutting down soon and reducing support for OSS repos too. This also has the advantage of testing on Github Actions.