### PR TITLE
fix: handle path with dollar signs

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ if (module.hot) {
 export default $2;
 `;
 
-	return code.replace(/(export default ([^;]*));/, replacement);
+	return code.replace(/(export default ([^;]*));/, () => replacement);
 }
 
 function posixify(file) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

If the filepath contains two dollar signs (`$$`) then the replacement here https://github.com/sveltejs/svelte-loader/blob/00e8607f25997e722d6dd6ba1e3b6977093f2f89/index.js#L49 removes one of them causing webpack to look for a path that doesn't exist

`.yarn/$$virtual/svelte-loader-virtual-ffb4749d44/2/svelte-loader/lib/hot-api.js` turns into `.yarn/$virtual/svelte-loader-virtual-ffb4749d44/2/svelte-loader/lib/hot-api.js`

**How did you fix it?**

Use the callback version of replace with uses the literal value provided