### PR TITLE
fix: handle path with dollar signs

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,9 @@ if (module.hot) {
 export default $2;
 `;
 
-	return code.replace(/(export default ([^;]*));/, () => replacement);
+	return code.replace(/(export default ([^;]*));/, (match, $1, $2) => {
+		return replacement.replace(/\$2/g, () => $2);
+	});
 }
 
 function posixify(file) {


### PR DESCRIPTION
**What's the problem this PR addresses?**

My fix in https://github.com/sveltejs/svelte-loader/pull/149 was broken and prevented the replacement of `$2`

**How did you fix it?**

Updated it so it still replaces `$2`