### PR TITLE
Drop Node 8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [ '8', '10', '12', '14' ]
+        node-version: [ '10', '12', '14' ]
         os: [ubuntu-latest, windows-latest]
     name: Test on Node v${{ matrix.node-version }} on ${{ matrix.os }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## 3.0.0 (unreleased)
 
 * Breaking: dropped Svelte 2 support ([#150](https://github.com/sveltejs/svelte-loader/pull/150))
-* Webpack 5 support ([#151](https://github.com/sveltejs/svelte-loader/pull/151))
-* Node 14 support and fix intermittent crashes when using `cache-loader` in front of `svelte-loader` ([#125](https://github.com/sveltejs/svelte-loader/pull/125))
+* Breaking: dropped Node 8 support ([#157](https://github.com/sveltejs/svelte-loader/pull/157))
+* Add Webpack 5 support ([#151](https://github.com/sveltejs/svelte-loader/pull/151))
+* Add Node 14 support and fix intermittent crashes when using `cache-loader` in front of `svelte-loader` ([#125](https://github.com/sveltejs/svelte-loader/pull/125))
 * Fix handling of paths containing `$$` ([#149](https://github.com/sveltejs/svelte-loader/pull/149))
 
 ## 2.13.6


### PR DESCRIPTION
Node 8 support was dropped from `rollup-plugin-svelte` and everywhere else. There's no reason this plugin won't work on Node 8, but as long as we're doing a major version bump we might as well drop officially supporting it so that we're not stuck with it in the future