### PR TITLE
Fix sourcesContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # svelte-loader changelog
 
+## 3.1.1 (Unreleased)
+
+* Fix empty sourcesContent ([#177](https://github.com/sveltejs/svelte-loader/pull/177))
+
 ## 3.1.0
 
 * Pass preprocessor source maps to compiler ([#172](https://github.com/sveltejs/svelte-loader/pull/172))

--- a/index.js
+++ b/index.js
@@ -50,6 +50,8 @@ module.exports = function(source, map) {
 		const compiled = compile(processed.toString(), compileOptions);
 		let { js, css, warnings } = compiled;
 
+		if (!js.map.sourcesContent) js.map.sourcesContent = [ source ];
+
 		warnings.forEach(
 			options.onwarn
 				? warning => options.onwarn(warning, handleWarning)


### PR DESCRIPTION
This repopulates sourcesContent if its empty.

Tested preprocessed and not preprocessed builds. Looks like everything is fine.

Haven't encountered anything weird like `sources[Content].length > 1` in my tests.

Thanks @rtpt-jonaslieb for the find.

Fixes #176.