### PR TITLE
Update to latest Svelte-HMR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # svelte-loader changelog
 
+## Unreleased
+
+* Update to latest `svelte-hmr` package fixing Webpack 4 support
+
 ## 3.1.1
 
 * Fix empty sourcesContent ([#177](https://github.com/sveltejs/svelte-loader/pull/177))

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const { relative } = require('path');
 const { getOptions } = require('loader-utils');
-const { makeHot } = require('./lib/make-hot.js');
+const { buildMakeHot } = require('./lib/make-hot.js');
 const { compile, preprocess } = require('svelte/compiler');
 
 function posixify(file) {
@@ -60,6 +60,7 @@ module.exports = function(source, map) {
 
 		if (options.hotReload && !isProduction && !isServer) {
 			const hotOptions = { ...options.hotOptions };
+			const makeHot = buildMakeHot(hotOptions);
 			const id = JSON.stringify(relative(process.cwd(), compileOptions.filename));
 			js.code = makeHot(id, js.code, hotOptions, compiled, source, compileOptions);
 		}

--- a/lib/make-hot.js
+++ b/lib/make-hot.js
@@ -3,10 +3,11 @@ const { createMakeHot } = require('svelte-hmr');
 
 const hotApi = require.resolve('./hot-api.js');
 
-const makeHot = createMakeHot({
+const buildMakeHot = (hotOptions) => createMakeHot({
 	walk,
 	meta: 'module',
 	hotApi,
+	hotOptions
 });
 
-module.exports.makeHot = makeHot;
+module.exports.buildMakeHot = buildMakeHot;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "loader-utils": "^2.0.0",
     "svelte-dev-helper": "^1.1.9",
-    "svelte-hmr": "^0.12.3"
+    "svelte-hmr": "^0.14.2"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -292,7 +292,7 @@ describe('loader', () => {
 						expect(err).not.to.exist;
 
 						expect(code).to.contain('module && module.hot');
-						expect(code).not.to.contain('"noPreserveState":true');
+						expect(code).not.to.contain('"preserveLocalState":true');
 					},
 					{ hotReload: true }
 				)
@@ -306,12 +306,12 @@ describe('loader', () => {
 						expect(err).not.to.exist;
 
 						expect(code).to.contain('module && module.hot');
-						expect(code).to.contain('"noPreserveState":true');
+						expect(code).to.contain('"preserveLocalState":true');
 					},
 					{
 						hotReload: true,
 						hotOptions: {
-							noPreserveState: true
+							preserveLocalState: true
 						}
 					}
 				)


### PR DESCRIPTION
This should resolve webpack4 support (#178 ) and pickup the latest HMR changes needed to fix Svelte Native support