### PR TITLE
warn on missing svelte condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ try {
 	if (!config.resolve || !config.resolve.conditionNames || !config.resolve.conditionNames.includes('svelte')) {
 		console.warn('\n\u001B[1m\u001B[31mWARNING: You should add "svelte" to the "resolve.conditionNames" array in your webpack config.\u001B[39m\u001B[22m\n');
 	}
-} catch {
+} catch (e) {
 	// do nothing and hope for the best
 }
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ for (let i = 0; i < process.argv.length; i++) {
 
 try {
 	const config = require(path.resolve(process.cwd(), config_file));
-	if (!config.resolve?.conditionNames?.includes('svelte')) {
+	if (!config.resolve || !config.resolve.conditionNames || !config.resolve.conditionNames.includes('svelte')) {
 		console.warn('\n\u001B[1m\u001B[31mWARNING: You should add "svelte" to the "resolve.conditionNames" array in your webpack config.\u001B[39m\u001B[22m\n');
 	}
 } catch {

--- a/index.js
+++ b/index.js
@@ -10,21 +10,21 @@ function posixify(file) {
 const virtualModules = new Map();
 let index = 0;
 
-let config_file = 'webpack.config.js';
+let configFile = 'webpack.config.js';
 for (let i = 0; i < process.argv.length; i++) {
 	if (process.argv[i] === '--config') {
-		config_file = process.argv[i + 1];
+		configFile = process.argv[i + 1];
 		break;
 	}
 
 	if (process.argv[i].startsWith('--config=')) {
-		config_file = process.argv[i].split('=')[1];
+		configFile = process.argv[i].split('=')[1];
 		break;
 	}
 }
 
 try {
-	const config = require(path.resolve(process.cwd(), config_file));
+	const config = require(path.resolve(process.cwd(), configFile));
 	if (!config.resolve || !config.resolve.conditionNames || !config.resolve.conditionNames.includes('svelte')) {
 		console.warn('\n\u001B[1m\u001B[31mWARNING: You should add "svelte" to the "resolve.conditionNames" array in your webpack config.\u001B[39m\u001B[22m\n');
 	}

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ for (let i = 0; i < process.argv.length; i++) {
 try {
 	const config = require(path.resolve(process.cwd(), configFile));
 	if (!config.resolve || !config.resolve.conditionNames || !config.resolve.conditionNames.includes('svelte')) {
-		console.warn('\n\u001B[1m\u001B[31mWARNING: You should add "svelte" to the "resolve.conditionNames" array in your webpack config.\u001B[39m\u001B[22m\n');
+		console.warn('\n\u001B[1m\u001B[31mWARNING: You should add "svelte" to the "resolve.conditionNames" array in your webpack config. See https://github.com/sveltejs/svelte-loader#resolveconditionnames for more information\u001B[39m\u001B[22m\n');
 	}
 } catch (e) {
 	// do nothing and hope for the best

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { relative } = require('path');
+const path = require('path');
 const { getOptions } = require('loader-utils');
 const { buildMakeHot } = require('./lib/make-hot.js');
 const { compile, preprocess } = require('svelte/compiler');
@@ -9,6 +9,28 @@ function posixify(file) {
 
 const virtualModules = new Map();
 let index = 0;
+
+let config_file = 'webpack.config.js';
+for (let i = 0; i < process.argv.length; i++) {
+	if (process.argv[i] === '--config') {
+		config_file = process.argv[i + 1];
+		break;
+	}
+
+	if (process.argv[i].startsWith('--config=')) {
+		config_file = process.argv[i].split('=')[1];
+		break;
+	}
+}
+
+try {
+	const config = require(path.resolve(process.cwd(), config_file));
+	if (!config.resolve?.conditionNames?.includes('svelte')) {
+		console.warn('\n\u001B[1m\u001B[31mWARNING: You should add "svelte" to the "resolve.conditionNames" array in your webpack config.\u001B[39m\u001B[22m\n');
+	}
+} catch {
+	// do nothing and hope for the best
+}
 
 module.exports = function(source, map) {
 	this.cacheable();
@@ -64,7 +86,7 @@ module.exports = function(source, map) {
 		if (options.hotReload && !isProduction && !isServer) {
 			const hotOptions = { ...options.hotOptions };
 			const makeHot = buildMakeHot(hotOptions);
-			const id = JSON.stringify(relative(process.cwd(), compileOptions.filename));
+			const id = JSON.stringify(path.relative(process.cwd(), compileOptions.filename));
 			js.code = makeHot(id, js.code, hotOptions, compiled, source, compileOptions);
 		}
 


### PR DESCRIPTION
We plan to release a version of `svelte-package` that encourages package authors to omit the `default` export condition. To resolve these packages, `svelte-loader` users are required to have `conditionNames: ['svelte']` in their webpack config.

With this change, we can identify cases where the field is not configured, and print a loud warning that will hopefully allow people to self-diagnose resolution failures and fix them. Once we ship docs for `svelte-package`, we could supplement this PR with a link to them.