### PR TITLE
drop support for Node 10 and Node 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: ["10", "12", "14", "16", "18"]
+        node-version: ["14", "16", "18"]
         os: [ubuntu-latest, windows-latest]
     name: Test on Node v${{ matrix.node-version }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm


### PR DESCRIPTION
Svelte 4 will be dropping support for these Node versions as well: https://github.com/sveltejs/svelte/pull/8482