### PR TITLE
Interop configPath default

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function posixify(file) {
 }
 
 function interopEsmDefault(mod) {
-	return mod && mod.__esModule ? mod.default : mod;
+	return mod && mod.__esModule && mod.default ? mod.default : mod;
 }
 
 const virtualModules = new Map();

--- a/index.js
+++ b/index.js
@@ -8,6 +8,10 @@ function posixify(file) {
 	return file.replace(/[/\\]/g, '/');
 }
 
+function interopEsmDefault(mod) {
+	return mod && mod.__esModule ? mod.default : mod;
+}
+
 const virtualModules = new Map();
 let index = 0;
 
@@ -26,7 +30,7 @@ for (let i = 0; i < process.argv.length; i++) {
 
 try {
 	const configPath = path.resolve(process.cwd(), configFile);
-	const config = require(configPath);
+	const config = interopEsmDefault(require(configPath));
 	let found = false;
 	if (Array.isArray(config)) {
 		found = config.some(check);


### PR DESCRIPTION
Fix loading the default module exports when config is ESM to suppress the warning of checking "resolve.conditionNames".