### PR TITLE
docs: add `browser` to `conditionNames`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Configure inside your `webpack.config.js`:
     },
     extensions: ['.mjs', '.js', '.svelte'],
     mainFields: ['svelte', 'browser', 'module', 'main'],
-    conditionNames: ['svelte']
+    conditionNames: ['svelte', 'browser']
   },
   module: {
     rules: [


### PR DESCRIPTION
We've got it in `mainFields`, so it should be in `conditionNames` as well. This will matter for Svelte 4 (https://github.com/sveltejs/svelte/pull/8516)