### PR TITLE
fix: loader errors when sourcemaps are disabled in svelte

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ module.exports = function(source, map) {
 		const compiled = compile(processed.toString(), compileOptions);
 		let { js, css, warnings } = compiled;
 
-		if (!js.map.sourcesContent) {
+		if (js.map && !js.map.sourcesContent) {
 			js.map.sourcesContent = [source];
 			js.map.sources = [compileOptions.filename];
 		}
@@ -124,7 +124,9 @@ module.exports = function(source, map) {
 		if (options.emitCss && css.code) {
 			const resource = posixify(compileOptions.filename);
 			const cssPath = `${resource}.${index++}.css`;
-			css.code += '\n/*# sourceMappingURL=' + css.map.toUrl() + '*/';
+			if (css.map) {
+				css.code += '\n/*# sourceMappingURL=' + css.map.toUrl() + '*/';
+			}
 			js.code += `\nimport '${cssPath}!=!svelte-loader?cssPath=${cssPath}!${resource}'\n;`;
 			virtualModules.set(cssPath, css.code);
 		}

--- a/test/loader.spec.js
+++ b/test/loader.spec.js
@@ -164,6 +164,34 @@ describe('loader', () => {
 					{ compilerOptions: { css: false } }
 				)
 			);
+
+			it(
+				'should configure css with dev sourcemaps',
+				testLoader(
+					'test/fixtures/css.html',
+					function(err, code, map) {
+						expect(err).not.to.exist;
+						expect(code).to.contain('function add_css(target)');
+						expect(code).to.contain('/*# sourceMappingURL=');
+						expect(map).to.exist;
+					},
+					{ compilerOptions: { dev: true, enableSourcemap: true } }
+				)
+			);
+
+			it(
+				'should configure css without dev sourcemaps',
+				testLoader(
+					'test/fixtures/css.html',
+					function(err, code, map) {
+						expect(err).not.to.exist;
+						expect(code).to.contain('function add_css(target)');
+						expect(code).not.to.contain('/*# sourceMappingURL=');
+						expect(map).to.exist;
+					},
+					{ compilerOptions: { dev: true, enableSourcemap: { css: false, js: true } } }
+				)
+			);
 		});
 
 		describe('sveltePath', () => {
@@ -232,6 +260,19 @@ describe('loader', () => {
 						expect(code).to.match(/!=!svelte-loader\?cssPath=/);
 					},
 					{ emitCss: true }
+				)
+			);
+
+			it(
+				'should configure emitCss=true without css sourcemaps',
+				testLoader(
+					'test/fixtures/css.html',
+					function(err, code, map) {
+						expect(err).not.to.exist;
+
+						expect(code).to.match(/!=!svelte-loader\?cssPath=/);
+					},
+					{ emitCss: true, compilerOptions: { enableSourcemap: { css: false, js: true } } }
 				)
 			);
 		});
@@ -352,6 +393,21 @@ describe('loader', () => {
 					},
 					{ hotReload: true }
 				)
+			);
+		});
+
+		describe('compilerOptions', () => {
+			it(
+				'should configure enableSourcemap=false',
+				testLoader(
+					'test/fixtures/good.html',
+					function(err, code, map) {
+						expect(err).not.to.exist;
+						expect(code).to.exist;
+						expect(map).not.to.exist;
+					},
+					{ compilerOptions: { enableSourcemap: false } }
+				),
 			);
 		});
 	});


### PR DESCRIPTION
This pull request fixes a couple errors I hit when setting `{ compilerOptions: { enableSourcemap: false } }`. At different places, the loader code assumes that each of `js.map` and `css.map` are non-null. Both errors are triggered in the added tests.

(I assume that disabling sourcemaps at the Svelte level rather than through the webpack config is uncommon. In my case, I was disabling CSS sourcemaps for Svelte specifically in order to work around some issues with preprocessor map handling. I found the JS sourcemap error in the course of fixing the CSS error.)