### PR TITLE
docs: extend default configuration for mainFields and conditionNames

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Configure inside your `webpack.config.js`:
       svelte: path.resolve('node_modules', 'svelte/src/runtime') // Svelte 3: path.resolve('node_modules', 'svelte')
     },
     extensions: ['.mjs', '.js', '.svelte'],
-    mainFields: ['svelte', 'browser', 'module', 'main'],
-    conditionNames: ['svelte', 'browser', 'import']
+    mainFields: ['svelte', 'browser', '...'],
+    conditionNames: ['svelte', 'browser', '...'],
   },
   module: {
     rules: [


### PR DESCRIPTION
Hello!

Some newer npm packages that rely on dynamic exports break with suggested `resolve.mainFields` and `resolve.conditionNames` configuration, since it lacks development mode and other things.

The `'...`' thing should re-add webpack's default configuration and make them all work good, while preferring `svelte` exports if any. :slightly_smiling_face: 